### PR TITLE
Remove import of unnecessary packages

### DIFF
--- a/src/processing/sound/Amplitude.java
+++ b/src/processing/sound/Amplitude.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 
 public class Amplitude {
 	

--- a/src/processing/sound/BrownNoise.java
+++ b/src/processing/sound/BrownNoise.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 
 public class BrownNoise implements Noise{
 	

--- a/src/processing/sound/Env.java
+++ b/src/processing/sound/Env.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 
 public class Env {
 	

--- a/src/processing/sound/FFT.java
+++ b/src/processing/sound/FFT.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 
 public class FFT {
 	

--- a/src/processing/sound/PinkNoise.java
+++ b/src/processing/sound/PinkNoise.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 
 public class PinkNoise implements Noise{
 	

--- a/src/processing/sound/SawOsc.java
+++ b/src/processing/sound/SawOsc.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 
 public class SawOsc implements Oscillator{
 	

--- a/src/processing/sound/SinOsc.java
+++ b/src/processing/sound/SinOsc.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 
 public class SinOsc implements Oscillator {
 	

--- a/src/processing/sound/SoundFile.java
+++ b/src/processing/sound/SoundFile.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 import java.io.File;
 
 public class SoundFile implements SoundObject {

--- a/src/processing/sound/WhiteNoise.java
+++ b/src/processing/sound/WhiteNoise.java
@@ -1,5 +1,5 @@
 package processing.sound;
-import processing.core.*;
+import processing.core.PApplet;
 
 public class WhiteNoise implements Noise{
 	


### PR DESCRIPTION
Replaced "import processing.core.*" with "import processing.core.PApplet" as the former was unnecessary . 
