### PR TITLE
Make Soundfile.loop() play stereo sounds more than once

### DIFF
--- a/src/cpp/processing_sound_MethClaInterface.cpp
+++ b/src/cpp/processing_sound_MethClaInterface.cpp
@@ -727,7 +727,10 @@ JNIEXPORT jintArray JNICALL Java_processing_sound_MethClaInterface_soundFilePlay
 
     request.whenDone(after.id(), Methcla::kNodeDoneFreeSelf | Methcla::kNodeDoneFreePreceeding);
     request.activate(synth.id());
-    request.activate(after.id());
+
+    if (loop == false) {
+        request.activate(after.id());
+    }
     request.closeBundle();
     
     engine().addNotificationHandler(engine().freeNodeIdHandler(synth.id()));


### PR DESCRIPTION
This pull request addresses #58.

Although I'm not entirely sure why that this is the best solution, as I don't understand underpinning MethCla library yet, here is why it's works and I think it makes sense:

The problem is caused by done callback initialized in line `request.whenDone(after.id(), Methcla::kNodeDoneFreeSelf | Methcla::kNodeDoneFreePreceeding);`, which activates after just one play, and as I understand, is a cleanup code. The problem is we still need the data that is being cleaned after one play (output to Processing console when using loop() suggests that), so the solution is NOT to activate this callback when we are using loop, which is what I do.

By the way, solution is inspired by code in lines 655-660, which handles the problem the same way for mono sounds (for which looping works). After testing it seems it also works for stereo sounds now, which makes sense ;)
