### PR TITLE
Use $ORIGIN for shared library rpath on Linux (64 bit)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -52,8 +52,7 @@
 	   encoding="UTF-8"
 	   includeAntRuntime="false"
 	   classpath="../processing/core/library/core.jar; library/sound.jar"
-	   nowarn="true"
-	   compiler="org.eclipse.jdt.core.JDTCompilerAdapter">
+	   nowarn="true">
       <compilerclasspath path="../processing/java/mode/org.eclipse.jdt.core.jar; 
                                ../processing/java/mode/jdtCompilerAdapter.jar" />
     </javac>

--- a/src/cpp/Makefile_Linux
+++ b/src/cpp/Makefile_Linux
@@ -1,13 +1,14 @@
 # needs gcc-4.7 or later
 CC := g++
+LIB_DIR = ../../library/linux64/
 
 all:
 	$(CC) -fPIC -I$(JAVA_INCLUDES)/linux -I./include -I$(JAVA_INCLUDES) -std=c++11 -g -c processing_sound_MethClaInterface.cpp
-	$(CC) -shared -Wl,-rpath,/usr/local/lib -o libMethClaInterface.so *.o -lmethcla
+	$(CC) -shared -L$(LIB_DIR) -Wl,-rpath,'$$ORIGIN' -o libMethClaInterface.so *.o -lmethcla
 
 clean:
 	rm *.o
 	rm *.jnilib
 
 install:
-	cp libMethClaInterface.so ../../library/linux
+	cp libMethClaInterface.so $(LIB_DIR)


### PR DESCRIPTION
Possible fix for #54
