### PR TITLE
Allow compilation for Linux 32

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Processing MethCla Interface
+## Processing Methcla Interface
 
-This is a processing interface and a collection of plugins for MethCla, a leight-weight, efficient sound engine for mobile devices [methcla](http://methc.la). For the moment this library is OSX + Linux only.
+This is a processing interface and a collection of plugins for [Methcla](http://methc.la), a leight-weight, efficient sound engine for mobile devices. For the moment this library is OSX + Linux only.
 
 
 ## Building the libMethClaInterface

--- a/README.md
+++ b/README.md
@@ -12,3 +12,39 @@ The Java Library is to be compiled with ant. Please install the latest version o
  ```
 
 in the root folder.
+
+## Building on Linux
+
+Install the following packages
+
+    g++
+    ant
+    openjdk-7-jdk
+
+Point the build scripts to the Java installation
+
+    export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+
+### Running the 32 bit version of processing (Ubuntu 14.04)
+
+Execute the following commands:
+
+    sudo dpkg --add-architecture i386
+    sudo apt-get update
+
+Install the following packages:
+
+    libc6:i386
+    libstdc++6:i386
+    libXext6:i386
+    libXrender1:i386
+    libXtst6:i386
+    libXi6:i386
+    libpulse0:i386
+
+### Compiling the 32 bit version of Processing Sound (Ubuntu 14.04)
+
+Install the following packages:
+
+    gcc-multilib
+    g++-multilib

--- a/build.xml
+++ b/build.xml
@@ -3,6 +3,8 @@
   <property environment="env" />
   <property file="build.properties" />
 
+  <property name="arch" value="64" />
+
   <condition property="platform" value="OSX">
     <os family="mac" />
   </condition>
@@ -19,7 +21,7 @@
       </not>
     </and>
   </condition>
-  
+
   <target name="clean" description="Clean the build directories">
     <delete dir="bin" />
     <delete file="library/sound.jar" />
@@ -30,12 +32,9 @@
 
   <target name="methcla" description="Compile and install methcla shared library.">
     <exec executable="make" dir="src/cpp" failonerror="true">
-      <arg line="-f Makefile_${platform}" />
+      <arg line="-f Makefile_${platform} ARCH=${arch} install" />
       <env key="PATH" path="${env.PATH}" />
       <env key="JAVA_INCLUDES" path="${java_includes}" />
-    </exec>
-    <exec executable="make" dir="src/cpp" failonerror="true">
-      <arg line="-f Makefile_${platform} install" />
     </exec>
   </target>
 

--- a/src/cpp/Makefile_Linux
+++ b/src/cpp/Makefile_Linux
@@ -1,18 +1,18 @@
 # needs gcc-4.7 or later
-CC := g++
+CXX := g++
 ARCH := 64
 LIB_DIR = ../../library/linux$(ARCH)/
 LIBRARY = libMethClaInterface.so
 
-.PHONY: clean install
+.PHONY: $(LIBRARY) clean install
 
 $(LIBRARY):
-	$(CC) -m$(ARCH) -fPIC -I$(JAVA_INCLUDES) -I$(JAVA_INCLUDES)/linux -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
-	$(CC) -m$(ARCH) -shared -L$(LIB_DIR) -Wl,-rpath,'$$ORIGIN' -o $@ *.o -lmethcla
+	$(CXX) -m$(ARCH) -fPIC -I$(JAVA_INCLUDES) -I$(JAVA_INCLUDES)/linux -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
+	$(CXX) -m$(ARCH) -shared -L$(LIB_DIR) -Wl,-rpath,'$$ORIGIN' -o $@ *.o -lmethcla
 
 clean:
 	rm *.o
 	rm *.jnilib
 
 install: $(LIBRARY)
-	cp $< $(LIB_DIR)
+	cp $(LIBRARY) $(LIB_DIR)

--- a/src/cpp/Makefile_Linux
+++ b/src/cpp/Makefile_Linux
@@ -7,7 +7,7 @@ LIBRARY = libMethClaInterface.so
 .PHONY: clean install
 
 $(LIBRARY):
-	$(CC) -m$(ARCH) -fPIC -I$(JAVA_INCLUDES)/linux -I./include -I$(JAVA_HOME)/include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
+	$(CC) -m$(ARCH) -fPIC -I$(JAVA_INCLUDES) -I$(JAVA_INCLUDES)/linux -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
 	$(CC) -m$(ARCH) -shared -L$(LIB_DIR) -Wl,-rpath,'$$ORIGIN' -o $@ *.o -lmethcla
 
 clean:

--- a/src/cpp/Makefile_Linux
+++ b/src/cpp/Makefile_Linux
@@ -1,14 +1,18 @@
 # needs gcc-4.7 or later
 CC := g++
-LIB_DIR = ../../library/linux64/
+ARCH := 64
+LIB_DIR = ../../library/linux$(ARCH)/
+LIBRARY = libMethClaInterface.so
 
-all:
-	$(CC) -fPIC -I$(JAVA_INCLUDES)/linux -I./include -I$(JAVA_INCLUDES) -std=c++11 -g -c processing_sound_MethClaInterface.cpp
-	$(CC) -shared -L$(LIB_DIR) -Wl,-rpath,'$$ORIGIN' -o libMethClaInterface.so *.o -lmethcla
+.PHONY: clean install
+
+$(LIBRARY):
+	$(CC) -m$(ARCH) -fPIC -I$(JAVA_INCLUDES)/linux -I./include -I$(JAVA_HOME)/include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
+	$(CC) -m$(ARCH) -shared -L$(LIB_DIR) -Wl,-rpath,'$$ORIGIN' -o $@ *.o -lmethcla
 
 clean:
 	rm *.o
 	rm *.jnilib
 
-install:
-	cp libMethClaInterface.so $(LIB_DIR)
+install: $(LIBRARY)
+	cp $< $(LIB_DIR)

--- a/src/cpp/Makefile_OSX
+++ b/src/cpp/Makefile_OSX
@@ -1,11 +1,17 @@
-all:
-	g++ -I$(JAVA_INCLUDES) -I$(JAVA_INCLUDES)/darwin -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
-	g++ -dynamiclib -lmethcla -L../../library/macosx/ -o libMethClaInterface.jnilib *.o
+CXX := c++
+LIB_DIR = ../../library/macosx/
+LIBRARY = libMethClaInterface.jnilib
+
+.PHONY: $(LIBRARY) clean install
+
+$(LIBRARY):
+	$(CXX) -I$(JAVA_INCLUDES) -I$(JAVA_INCLUDES)/darwin -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
+	$(CXX) -dynamiclib -lmethcla -L$(LIB_DIR) -o $@ *.o
 
 clean:
 	rm *.o
 	rm *.jnilib
 
-install:
-	install_name_tool -change @executable_path/libmethcla.dylib  @loader_path/libmethcla.dylib libMethClaInterface.jnilib
-	cp libMethClaInterface.jnilib ../../library/macosx
+install: $(LIBRARY)
+	install_name_tool -change @executable_path/libmethcla.dylib  @loader_path/libmethcla.dylib $(LIBRARY)
+	cp $(LIBRARY) $(LIB_DIR)

--- a/src/cpp/Makefile_Win
+++ b/src/cpp/Makefile_Win
@@ -7,4 +7,4 @@ clean:
 	rm *.dll
 
 install:
-	cp libMethClaInterface.dll ../../lib/windows64
+	cp libMethClaInterface.dll ../../library/windows64

--- a/src/cpp/Makefile_Win
+++ b/src/cpp/Makefile_Win
@@ -1,5 +1,5 @@
 all:
-	g++ -Ic:$(JAVA_INCLUDES) -Ic:$(JAVA_INCLUDES)/win32 -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
+	g++ -I$(JAVA_INCLUDES) -I$(JAVA_INCLUDES)/win32 -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
 	g++ -shared -lmethcla -L../../library/windows64/ -static-libgcc -static-libstdc++ -o libMethClaInterface.dll *.o
 
 clean:

--- a/src/cpp/Makefile_Win
+++ b/src/cpp/Makefile_Win
@@ -1,10 +1,17 @@
-all:
-	g++ -I$(JAVA_INCLUDES) -I$(JAVA_INCLUDES)/win32 -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
-	g++ -shared -lmethcla -L../../library/windows64/ -static-libgcc -static-libstdc++ -o libMethClaInterface.dll *.o
+CXX := g++
+ARCH := 64
+LIB_DIR = ../../library/windows$(ARCH)/
+LIBRARY = libMethClaInterface.dll
+
+.PHONY: $(LIBRARY) clean install
+
+$(LIBRARY):
+	$(CXX) -I$(JAVA_INCLUDES) -I$(JAVA_INCLUDES)/win32 -I./include -std=c++11 -g -c processing_sound_MethClaInterface.cpp
+	$(CXX) -shared -lmethcla -L$(LIB_DIR) -static-libgcc -static-libstdc++ -o $@ *.o
 
 clean:
 	rm *.o
 	rm *.dll
 
-install:
-	cp libMethClaInterface.dll ../../library/windows64
+install: $(LIBRARY)
+	cp $(LIBRARY) $(LIB_DIR)


### PR DESCRIPTION
Allow cross-compiling for Linux 32 (tested on Ubuntu 14.04 amd64).

Compile with

```
$ cd src/cpp
$ make -f Makefile_Linux ARCH=32 install
```

Loading the library into Processing's 32 bit version succeeds now but crashes when running an example sketch (will submit an issue for this).
